### PR TITLE
Fix automatic webhook subscription

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,9 +3,22 @@ import threading
 import requests
 import os
 from google_sheet import get_active_pages
+from watch_comments import subscribe_page_to_webhooks
 
 app = Flask(__name__)
 thread_started = False  # Flag global
+
+def subscribe_all_pages():
+    """Abonne toutes les pages configurées aux webhooks."""
+    try:
+        pages = get_active_pages()
+        for page in pages:
+            subscribe_page_to_webhooks(page["page_id"])
+    except Exception as e:
+        print(f"❌ Erreur abonnement pages : {e}")
+
+# Souscription immédiate au démarrage de l'application
+subscribe_all_pages()
 
 def watch_comments():
     print("🧠 Début du thread de détection de commentaires")
@@ -18,7 +31,10 @@ def watch_comments():
 
     print("🔁 Boucle de vérification des pages actives :")
     for pid in page_ids:
-        print(f"➡️ Page active : {pid['page_id']} (Instagram : {pid['instagram_id']}, Client : {pid['client_name']})")
+        print(
+            f"➡️ Page active : {pid['page_id']} (Instagram : {pid['instagram_id']}, Client : {pid['client_name']})"
+        )
+        subscribe_page_to_webhooks(pid["page_id"])
 
 @app.before_request
 def start_thread_once():

--- a/watch_comments.py
+++ b/watch_comments.py
@@ -9,6 +9,24 @@ MAKE_WEBHOOK = os.environ.get("MAKE_WEBHOOK_COMMENTS")
 # Cache local pour suivre les commentaires déjà vus
 last_seen_comments = {}
 
+def subscribe_page_to_webhooks(page_id):
+    """Abonne la page Facebook aux webhooks Instagram."""
+    url = f"https://graph.facebook.com/v19.0/{page_id}/subscribed_apps"
+    payload = {
+        "subscribed_fields": "instagram_comments",
+        "access_token": META_TOKEN,
+    }
+    try:
+        response = requests.post(url, data=payload)
+        if response.ok:
+            print(f"✅ Page {page_id} abonnée aux webhooks")
+        else:
+            print(
+                f"⚠️ Échec abonnement page {page_id}: {response.status_code} {response.text}"
+            )
+    except Exception as e:
+        print(f"❌ Exception abonnement page {page_id}: {e}")
+
 def get_comments(instagram_id):
     url = f"https://graph.facebook.com/v19.0/{instagram_id}/media?fields=id,comments{{id,text,timestamp,username}}&access_token={META_TOKEN}"
     try:


### PR DESCRIPTION
## Summary
- add `subscribe_page_to_webhooks` helper
- subscribe all pages to webhooks on startup
- call subscription from watcher thread

## Testing
- `python -m py_compile watch_comments.py main.py google_sheet.py keep_alive.py reply.py webhook.py watch_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_68491b1a8c94832fbba7d3a494f7c227