### PR TITLE
Fix webhook subscription field for Instagram comments

### DIFF
--- a/watch_comments.py
+++ b/watch_comments.py
@@ -10,10 +10,13 @@ MAKE_WEBHOOK = os.environ.get("MAKE_WEBHOOK_COMMENTS")
 last_seen_comments = {}
 
 def subscribe_page_to_webhooks(page_id):
-    """Abonne la page Facebook aux webhooks Instagram."""
+    """Abonne la page Facebook aux webhooks pour recevoir les commentaires Instagram."""
     url = f"https://graph.facebook.com/v19.0/{page_id}/subscribed_apps"
     payload = {
-        "subscribed_fields": "instagram_comments",
+        # Selon la documentation Meta Graph API, le champ correct est
+        # "comments" afin de recevoir les commentaires Instagram relayés
+        # via la Page Facebook associée.
+        "subscribed_fields": "comments",
         "access_token": META_TOKEN,
     }
     try:


### PR DESCRIPTION
## Summary
- subscribe pages with valid `comments` field

## Testing
- `python -m py_compile watch_comments.py main.py webhook.py google_sheet.py watch_posts.py reply.py keep_alive.py`

------
https://chatgpt.com/codex/tasks/task_e_68492a0ff410832f829fbb02c1e2e900