### PR TITLE
Add comment reply endpoint

### DIFF
--- a/reply.py
+++ b/reply.py
@@ -1,13 +1,36 @@
-import requests, os
+import os
+from typing import Dict
 
-ACCESS_TOKEN = os.getenv("META_SYSTEM_TOKEN")
+import requests
 
-def reply_to_comment(comment_id, message):
+
+def reply_to_comment(comment_id: str, message: str) -> Dict:
+    """Reply to a given Instagram comment via the Meta Graph API.
+
+    Parameters
+    ----------
+    comment_id: str
+        The ID of the comment to reply to.
+    message: str
+        The reply message.
+
+    Returns
+    -------
+    dict
+        Parsed JSON response from the Meta API.
+    """
+
+    access_token = os.getenv("META_SYSTEM_TOKEN")
+    if not access_token:
+        raise RuntimeError("META_SYSTEM_TOKEN environment variable is not set")
+
     url = f"https://graph.facebook.com/v19.0/{comment_id}/replies"
-    payload = {"message": message, "access_token": ACCESS_TOKEN}
-    response = requests.post(url, data=payload)
+    payload = {"message": message, "access_token": access_token}
 
-    if response.ok:
-        print(f"✅ Réponse envoyée à {comment_id}")
-    else:
-        print(f"❌ Erreur en répondant à {comment_id}: {response.text}")
+    try:
+        response = requests.post(url, data=payload)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Request to Meta API failed: {exc}") from exc
+


### PR DESCRIPTION
## Summary
- add API utility to send replies to comments
- expose `/reply` endpoint in Flask app

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py reply.py`
- `python - <<'PY'
from reply import reply_to_comment
print('func exists:', callable(reply_to_comment))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6849529a45ec832fbfd79b71c136f20c