### PR TITLE
Use watch_new_comments thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import threading
 import requests
 import os
 from google_sheet import get_active_pages
-from watch_comments import subscribe_page_to_webhooks
+from watch_comments import subscribe_page_to_webhooks, watch_new_comments
 from reply import reply_to_comment
 
 app = Flask(__name__)
@@ -41,8 +41,8 @@ def watch_comments():
 def start_thread_once():
     global thread_started
     if not thread_started:
-        print("🚀 Lancement du thread une seule fois")
-        threading.Thread(target=watch_comments).start()
+        print("🚀 Lancement du thread de surveillance des commentaires")
+        threading.Thread(target=watch_new_comments, daemon=True).start()
         thread_started = True
 
 @app.route("/")


### PR DESCRIPTION
## Summary
- run the rapid comment watcher on startup

## Testing
- `python -m py_compile main.py watch_comments.py watch_posts.py keep_alive.py google_sheet.py reply.py webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_684975c9f528832fbad4e42434026203