### PR TITLE
Fix IG comments webhook subscription

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,18 +3,18 @@ import threading
 import requests
 import os
 from google_sheet import get_active_pages
-from watch_comments import subscribe_page_to_webhooks, watch_new_comments
+from watch_comments import subscribe_ig_account_to_webhooks, watch_new_comments
 from reply import reply_to_comment
 
 app = Flask(__name__)
 thread_started = False  # Flag global
 
 def subscribe_all_pages():
-    """Abonne toutes les pages configurées aux webhooks."""
+    """Abonne tous les comptes Instagram Business configurés aux webhooks."""
     try:
         pages = get_active_pages()
         for page in pages:
-            subscribe_page_to_webhooks(page["page_id"])
+            subscribe_ig_account_to_webhooks(page["instagram_id"])
     except Exception as e:
         print(f"❌ Erreur abonnement pages : {e}")
 
@@ -35,7 +35,7 @@ def watch_comments():
         print(
             f"➡️ Page active : {pid['page_id']} (Instagram : {pid['instagram_id']}, Client : {pid['client_name']})"
         )
-        subscribe_page_to_webhooks(pid["page_id"])
+        subscribe_ig_account_to_webhooks(pid["instagram_id"])
 
 @app.before_request
 def start_thread_once():

--- a/watch_comments.py
+++ b/watch_comments.py
@@ -3,35 +3,34 @@ import time
 import requests
 from google_sheet import fetch_page_ids
 
-META_TOKEN = os.environ.get("META_SYSTEM_TOKEN")
+# Token système déjà fourni via les variables d'environnement
+system_token = os.environ.get("META_SYSTEM_TOKEN")
 MAKE_WEBHOOK = os.environ.get("MAKE_WEBHOOK_COMMENTS")
 
 # Cache local pour suivre les commentaires déjà vus
 last_seen_comments = {}
 
-def subscribe_page_to_webhooks(page_id):
-    """Abonne la page Facebook aux webhooks pour recevoir les commentaires Instagram."""
-    url = f"https://graph.facebook.com/v19.0/{page_id}/subscribed_apps"
+def subscribe_ig_account_to_webhooks(instagram_business_id):
+    """Abonne le compte Instagram Business aux webhooks pour les commentaires."""
+    url = f"https://graph.facebook.com/v19.0/{instagram_business_id}/subscribed_apps"
     payload = {
-        # Selon la documentation Meta Graph API, le champ correct est
-        # "comments" afin de recevoir les commentaires Instagram relayés
-        # via la Page Facebook associée.
-        "subscribed_fields": "comments",
-        "access_token": META_TOKEN,
+        # Pour les commentaires Instagram, le champ à souscrire est 'instagram_comments'
+        "subscribed_fields": "instagram_comments",
+        "access_token": system_token,
     }
     try:
         response = requests.post(url, data=payload)
         if response.ok:
-            print(f"✅ Page {page_id} abonnée aux webhooks")
+            print(f"✅ IBA {instagram_business_id} abonné aux webhooks")
         else:
             print(
-                f"⚠️ Échec abonnement page {page_id}: {response.status_code} {response.text}"
+                f"⚠️ Échec abonnement IBA {instagram_business_id}: {response.status_code} {response.text}"
             )
     except Exception as e:
-        print(f"❌ Exception abonnement page {page_id}: {e}")
+        print(f"❌ Exception abonnement IBA {instagram_business_id}: {e}")
 
 def get_comments(instagram_id):
-    url = f"https://graph.facebook.com/v19.0/{instagram_id}/media?fields=id,comments{{id,text,timestamp,username}}&access_token={META_TOKEN}"
+    url = f"https://graph.facebook.com/v19.0/{instagram_id}/media?fields=id,comments{{id,text,timestamp,username}}&access_token={system_token}"
     try:
         res = requests.get(url)
         res.raise_for_status()


### PR DESCRIPTION
## Summary
- use instagram business ID when subscribing to the webhook
- rely on system token for authentication

## Testing
- `python -m py_compile watch_comments.py main.py reply.py webhook.py keep_alive.py google_sheet.py watch_posts.py`

------
https://chatgpt.com/codex/tasks/task_e_684a99122ca8832f962294f0883db60e