### PR TITLE
Fix missing Supabase key

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ from utils import (
 app = Flask(__name__)
 
 SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_KEY")
+# Allow both SUPABASE_KEY and SUPABASE_SERVICE_KEY for backward compatibility
+SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
 BASE_REDIRECT_URL = os.getenv("BASE_REDIRECT_URL")
 ADMIN_EMAIL = os.getenv("ADMIN_EMAIL")
 


### PR DESCRIPTION
## Summary
- accept `SUPABASE_SERVICE_KEY` or `SUPABASE_KEY` for backwards compatibility

## Testing
- `python -m py_compile main.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685e35521d68832f9b40c05e7bfa89a1